### PR TITLE
0.0.18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rosemary_ai"
-version = "0.0.17"
+version = "0.0.18"
 authors = [{name="Samjna", mailto="snw201510@gmail.com"}]
 description = "A Template Engine For LLMs and Generative AIs"
 readme = "README_PYPI.md"

--- a/src/rosemary_ai/_utils/dict_utils.py
+++ b/src/rosemary_ai/_utils/dict_utils.py
@@ -5,6 +5,6 @@ def options_with_default(options: Dict[str, Any], default_options: Dict[str, Any
     if default_options is None:
         return options
     if options is None:
-        return default_options
+        return default_options.copy()
 
     return default_options | options

--- a/src/rosemary_ai/models/_model_info.py
+++ b/src/rosemary_ai/models/_model_info.py
@@ -3,6 +3,7 @@ GPT = {
     'gpt-4': ['gpt-4'],
     'gpt-4-turbo': ['gpt-4-turbo', 'gpt-4-t'],
     'gpt-4o': ['gpt-4o'],
+    'gpt-4o-2024-08-06': ['gpt-4o-0806'],
     'gpt-4o-mini': ['gpt-4o-mini', 'gpt-4o-m']
 }
 

--- a/src/rosemary_ai/models/_utils.py
+++ b/src/rosemary_ai/models/_utils.py
@@ -55,6 +55,8 @@ def update_options(options: Dict[str, Any], new_options: Dict[str, List[str]], o
     Update options with new options. The new options is raw data from formatter,
     so a list of string should be converted to a string.
     It will Also cast the values to the correct type.
+
+    Legacy: Now we assume that the new options are already formatted.
     """
 
     # if option_types is None:

--- a/src/rosemary_ai/rosemary.py
+++ b/src/rosemary_ai/rosemary.py
@@ -1,5 +1,5 @@
 import typing
-from inspect import Signature
+from inspect import Signature, isclass
 from typing import Callable, Dict, Any, Tuple, Generator
 
 from ._global_settings import SETTINGS
@@ -342,10 +342,14 @@ class Rosemary:
         if signature.return_annotation is not _EMPTY:
             annotation = signature.return_annotation
 
-            if issubclass(typing.get_origin(annotation), typing.Generator):
+            if (
+                    isclass(typing.get_origin(annotation)) and
+                    issubclass(typing.get_origin(annotation), typing.Generator)
+            ):
                 data_type = typing.get_args(annotation)[0]
             else:
-                LOGGER.warning(f'Return type "{annotation}" of "{function_name}" is not a generator type.')
+                LOGGER.warning(f'Return type "{annotation}" of "{function_name}" is not a generator type.'
+                               f'The return type will not be checked.')
 
         def __set_up(kwargs: Dict[str, Any], args: Tuple[Any],
                      options_: Dict[str, Any], max_tries: int,


### PR DESCRIPTION
GPT model 'gpt-4o-2024-08-04' added cause this one is cheaper.
Function calls for gpt models supported (only for single request, i.e. no chaining).
For GPT models, added an option to directly return the messages in json format for batch or fine-tuning.